### PR TITLE
feat: support @range/@uniform-range comments

### DIFF
--- a/example/src/experience.ts
+++ b/example/src/experience.ts
@@ -1,11 +1,5 @@
 import { OrbitControls } from "three/examples/jsm/Addons.js";
-import {
-  Fn,
-  mix,
-  positionGeometry,
-  remap,
-  uniform,
-} from "three/tsl";
+import { Fn, mix, positionGeometry, remap, uniform } from "three/tsl";
 import * as THREE from "three/webgpu";
 
 export class Experience {
@@ -100,7 +94,10 @@ export class Experience {
     const color2 = uniform(new THREE.Color(0x00ff00));
     // const progress = uniform(0);
 
+    // @range: { min: 0.1, max: 3, step: 0.1 }
     const scale = uniform(1, "float");
+
+    // @range: { min: -2, max: 2, step: 0.1 }
     const position = uniform(new THREE.Vector3(0, 0, 0), "vec3");
 
     // const tex = new THREE.TextureLoader().load("/uv.png");

--- a/package/index.ts
+++ b/package/index.ts
@@ -57,6 +57,11 @@ interface UniformInfo {
     | "matrix4"
     | "texture";
   position: number;
+  range?: {
+    min?: number;
+    max?: number;
+    step?: number;
+  };
 }
 
 const debug = {
@@ -67,6 +72,37 @@ const debug = {
   error: (...args: any[]) =>
     console.log("\x1b[31m%s\x1b[0m", "[three-uniform-gui][error]", ...args),
 };
+
+// Function to parse range configuration from comments
+function parseRangeComment(comments: any[]): UniformInfo["range"] | undefined {
+  if (!comments) return undefined;
+
+  for (const comment of comments) {
+    // Support multiple comment formats:
+    // @uniform-range: { min: 0, max: 2, step: 0.1 }
+    // @range: { min: 0, max: 2, step: 0.1 }
+    const match = comment.value.match(/@(?:uniform-)?range:\s*(\{[\s\S]*?\})/);
+    if (match) {
+      let configStr = match[1];
+      try {
+        return JSON.parse(configStr);
+      } catch (e) {
+        // Try adding quotes to unquoted keys
+        const quotedStr = configStr.replace(
+          /([{,]\s*)([a-zA-Z_]\w*)\s*:/g,
+          '$1"$2":'
+        );
+        try {
+          return JSON.parse(quotedStr);
+        } catch (e2) {
+          debug.warn("Invalid uniform range configuration:", configStr);
+          return undefined;
+        }
+      }
+    }
+  }
+  return undefined;
+}
 
 // All the existing type detection and control generation functions...
 function getUniformType(
@@ -168,6 +204,14 @@ function generateControl(
 
     // [All other cases]
     case "number":
+      // Build range options string
+      const rangeOptions = uniform.range
+        ? Object.entries(uniform.range)
+            .filter(([_, value]) => value !== undefined)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(",\n            ")
+        : "step: 0.01";
+
       return addSubfolder(
         folderName,
         `
@@ -181,16 +225,16 @@ function generateControl(
           }
         folder.addBinding(${uniform.name}, 'value', {
             label: '${uniform.name}',
-            step: 0.01
+            ${rangeOptions}
           }).on("change", () => {
               ${persistent} && window.uniformPane.uniformSaveDebounced()
           });
       `
       );
-      case "color":
-        return addSubfolder(
-          folderName,
-          `
+    case "color":
+      return addSubfolder(
+        folderName,
+        `
           if(window.uniformPane.initialUniformState){
               if(window.uniformPane.initialUniformState.${folderName}?.${uniform.name}){
                 const color = JSON.parse(window.uniformPane.initialUniformState.${folderName}.${uniform.name} )
@@ -209,21 +253,29 @@ function generateControl(
                 ${persistent} && window.uniformPane.uniformSaveDebounced()
           });
         `
-        );
-  
-      case "vector2":
-      case "vector3":
-      case "vector4":
-        const axes =
-          uniform.type === "vector2"
-            ? ["x", "y"]
-            : uniform.type === "vector3"
-            ? ["x", "y", "z"]
-            : ["x", "y", "z", "w"];
-  
-        return addSubfolder(
-          folderName,
-          `
+      );
+
+    case "vector2":
+    case "vector3":
+    case "vector4":
+      const axes =
+        uniform.type === "vector2"
+          ? ["x", "y"]
+          : uniform.type === "vector3"
+          ? ["x", "y", "z"]
+          : ["x", "y", "z", "w"];
+
+      // Build range options string for vector components
+      const vectorRangeOptions = uniform.range
+        ? Object.entries(uniform.range)
+            .filter(([_, value]) => value !== undefined)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(",\n              ")
+        : "step: 0.01";
+
+      return addSubfolder(
+        folderName,
+        `
           const ${uniform.name}Folder = folder.addFolder({
             title: '${uniform.name}'
           }) 
@@ -242,7 +294,7 @@ function generateControl(
               }
             ${uniform.name}Folder.addBinding(${uniform.name}.value, '${axis}', {
               label: '${axis}',
-              step: 0.01
+              ${vectorRangeOptions}
             }).on("change", () => {
               ${persistent} &&  window.uniformPane.uniformSaveDebounced()
             });
@@ -250,11 +302,11 @@ function generateControl(
             })
             .join("\n")}
         `
-        );
-      case "texture":
-        return addSubfolder(
-          folderName,
-          ` const ${uniform.name}Params = {
+      );
+    case "texture":
+      return addSubfolder(
+        folderName,
+        ` const ${uniform.name}Params = {
               file: "",
             }
             const ${uniform.name}Folder = folder.addFolder({
@@ -276,26 +328,30 @@ function generateControl(
               ${uniform.name}.value = texture;
               ${persistent} && window.uniformPane.uniformSaveDebounced()
             });`
-        );
-      default:
-        return "";
+      );
+    default:
+      return "";
   }
 }
 
 // Updated plugin function to accept options
-export default function threeUniformGuiPlugin(options?: ThreeUniformGuiOptions | boolean): Plugin {
+export default function threeUniformGuiPlugin(
+  options?: ThreeUniformGuiOptions | boolean
+): Plugin {
   // Handle backward compatibility - if a boolean is passed, treat it as the persistent option
-  const opts = typeof options === 'boolean' 
-    ? { ...defaultOptions, persistent: options } 
-    : { ...defaultOptions, ...options };
+  const opts =
+    typeof options === "boolean"
+      ? { ...defaultOptions, persistent: options }
+      : { ...defaultOptions, ...options };
 
-    debug.log("Options:", opts);
+  debug.log("Options:", opts);
 
   return {
     name: "three-uniform-gui",
+    enforce: "pre",
     apply: (config, { command }) => {
       // Only apply in development mode if devOnly is true
-      if (opts.devOnly && command !== 'serve') {
+      if (opts.devOnly && command !== "serve") {
         return false;
       }
       return true;
@@ -309,10 +365,13 @@ export default function threeUniformGuiPlugin(options?: ThreeUniformGuiOptions |
         const ast = parser.parse(code, {
           sourceType: "module",
           plugins: ["typescript", "jsx"],
-        });
+          comments: true,
+          attachComments: true, // Enable comment parsing
+        } as any);
 
         const uniforms: UniformInfo[] = [];
         let paneExists = false;
+        const fileComments: any[] = (ast as any).comments || [];
 
         traverse(ast, {
           VariableDeclarator(path: NodePath<t.VariableDeclarator>) {
@@ -332,6 +391,7 @@ export default function threeUniformGuiPlugin(options?: ThreeUniformGuiOptions |
                 if (
                   binding &&
                   binding.kind !== "module" &&
+                  t.isVariableDeclarator(binding.path.node) &&
                   binding.path.node.init
                 ) {
                   const initNode = binding.path.node.init;
@@ -340,10 +400,36 @@ export default function threeUniformGuiPlugin(options?: ThreeUniformGuiOptions |
               }
 
               if (type && path.node.end) {
+                // Parse comments near this declaration for range configuration
+                const nodeStart = (path.node.start as number) || 0;
+                // Find the nearest preceding comment with minimal separation
+                let nearestComment: any | undefined;
+                for (let i = fileComments.length - 1; i >= 0; i -= 1) {
+                  const c = fileComments[i];
+                  if (typeof c.end === "number" && c.end <= nodeStart) {
+                    const between = code.slice(c.end, nodeStart);
+                    // Allow at most one newline and only whitespace between comment and node
+                    const newlineCount = (between.match(/\n/g) || []).length;
+                    if (/^[\s;]*$/.test(between) && newlineCount <= 1) {
+                      nearestComment = c;
+                      break;
+                    }
+                    // If there is too much separation, stop searching further
+                    if (newlineCount > 1) break;
+                  }
+                }
+                const candidateComments = [
+                  ...(nearestComment ? [nearestComment] : []),
+                  ...((path.parent as any).leadingComments || []),
+                  ...((path.node as any).leadingComments || []),
+                ];
+                const rangeConfig = parseRangeComment(candidateComments);
+
                 uniforms.push({
                   name: path.node.id.name,
                   type,
                   position: path.node.end,
+                  range: rangeConfig,
                 });
               }
             }

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,11 @@
 # tsl-uniform-ui-vite-plugin
-A Vite plugin that automatically generates GUI controls for Three.js shader uniforms using Tweakpane. This plugin simplifies shader development by providing real-time controls for uniform values without manual GUI setup.
+
+A Vite plugin that automatically generates GUI controls for Three.js shader
+uniforms using Tweakpane. This plugin simplifies shader development by providing
+real-time controls for uniform values without manual GUI setup.
 
 ## Features
+
 - Automatic GUI generation for shader uniforms
 - Supports multiple uniform types:
   - Boolean
@@ -16,29 +20,35 @@ A Vite plugin that automatically generates GUI controls for Three.js shader unif
 - Development-only mode (disabled in production by default)
 
 ## Installation
+
 ```bash
 npm install tsl-uniform-ui-vite-plugin @tweakpane/core tweakpane @tweakpane/plugin-essentials tweakpane-plugin-file-import
 ```
 
 ## Usage
+
 1. Add the plugin to your Vite config:
+
 ```javascript
 // vite.config.js
-import threeUniformGui from 'tsl-uniform-ui-vite-plugin';
+import threeUniformGui from "tsl-uniform-ui-vite-plugin";
 
 export default {
-  plugins: [threeUniformGui()]
-}
+  plugins: [threeUniformGui()],
+};
 ```
 
 2. Define your uniforms using the `uniform()` function:
+
 ```javascript
-import { uniform } from 'three/tsl';
-const brightness = uniform(1.0);  // number
-const color = uniform(new THREE.Color(1, 0, 0));  // color
-const position = uniform(new THREE.Vector3(0, 1, 0));  // vector3
+import { uniform } from "three/tsl";
+const brightness = uniform(1.0); // number
+const color = uniform(new THREE.Color(1, 0, 0)); // color
+const position = uniform(new THREE.Vector3(0, 1, 0)); // vector3
 ```
-The plugin will automatically generate appropriate Tweakpane controls for each uniform based on its type.
+
+The plugin will automatically generate appropriate Tweakpane controls for each
+uniform based on its type.
 
 ## Configuration Options
 
@@ -46,80 +56,125 @@ You can configure the plugin with the following options:
 
 ```javascript
 // vite.config.js
-import threeUniformGui from 'tsl-uniform-ui-vite-plugin';
+import threeUniformGui from "tsl-uniform-ui-vite-plugin";
 
 export default {
   plugins: [
     threeUniformGui({
-      persistent: true,  // Save configurations in localStorage
-      devOnly: true      // Only active in development mode (default)
-    })
-  ]
-}
+      persistent: true, // Save configurations in localStorage
+      devOnly: true, // Only active in development mode (default)
+    }),
+  ],
+};
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `persistent` | boolean | `false` | Save UI state in localStorage |
-| `devOnly` | boolean | `true` | Only enable the plugin in development mode |
+| Option       | Type    | Default | Description                                |
+| ------------ | ------- | ------- | ------------------------------------------ |
+| `persistent` | boolean | `false` | Save UI state in localStorage              |
+| `devOnly`    | boolean | `true`  | Only enable the plugin in development mode |
 
 For backward compatibility, you can still use the old configuration style:
 
 ```javascript
 // vite.config.js - Legacy style
-import threeUniformGui from 'tsl-uniform-ui-vite-plugin';
+import threeUniformGui from "tsl-uniform-ui-vite-plugin";
 
 export default {
-  plugins: [threeUniformGui(true)] // Persistent mode, dev only
-}
+  plugins: [threeUniformGui(true)], // Persistent mode, dev only
+};
 ```
 
 ## Supported Types
-| Type | Example | GUI Control |
-|------|---------|------------|
-| Boolean | `uniform(false)` | Checkbox |
-| Number | `uniform(1.0)` | Slider |
-| Color | `uniform(new THREE.Color())` | Color Picker |
-| Vector2 | `uniform(new THREE.Vector2())` | X/Y Sliders |
-| Vector3 | `uniform(new THREE.Vector3())` | X/Y/Z Sliders |
-| Vector4 | `uniform(new THREE.Vector4())` | X/Y/Z/W Sliders |
-| Texture | `texture(new THREE.TextureLoader().load("/uv.png"))` | File Picker |
+
+| Type    | Example                                              | GUI Control     |
+| ------- | ---------------------------------------------------- | --------------- |
+| Boolean | `uniform(false)`                                     | Checkbox        |
+| Number  | `uniform(1.0)`                                       | Slider          |
+| Color   | `uniform(new THREE.Color())`                         | Color Picker    |
+| Vector2 | `uniform(new THREE.Vector2())`                       | X/Y Sliders     |
+| Vector3 | `uniform(new THREE.Vector3())`                       | X/Y/Z Sliders   |
+| Vector4 | `uniform(new THREE.Vector4())`                       | X/Y/Z/W Sliders |
+| Texture | `texture(new THREE.TextureLoader().load("/uv.png"))` | File Picker     |
+
+## Range Configuration
+
+You can specify custom ranges for number and vector uniforms using comment-based
+configuration:
+
+```javascript
+// @range: { min: 0, max: 2, step: 0.1 }
+const brightness = uniform(1.0);
+
+// @range: { min: -5, max: 5, step: 0.5 }
+const position = uniform(new THREE.Vector3(0, 0, 0), "vec3");
+```
+
+The comment must be placed directly above the uniform declaration. Supported
+options:
+
+- `min`: Minimum value for the slider
+- `max`: Maximum value for the slider
+- `step`: Step size for the slider (default: 0.01)
+
+You can also use the alternative syntax:
+
+```javascript
+// @uniform-range: { min: 0, max: 2, step: 0.1 }
+const brightness = uniform(1.0);
+```
 
 ## Caveat
+
 ### Passing Types to the uniform Function
-When using the uniform() function, the plugin can sometimes automatically infer the type of the uniform based on the value you pass. However, there are specific cases where you must provide the type explicitly as a second argument to ensure the plugin generates the correct GUI controls.
+
+When using the uniform() function, the plugin can sometimes automatically infer
+the type of the uniform based on the value you pass. However, there are specific
+cases where you must provide the type explicitly as a second argument to ensure
+the plugin generates the correct GUI controls.
 
 ### When Type Inference Works
+
 The plugin can automatically determine the type in these situations:
-- **Literals**: When you pass a direct value like a number, boolean, or a Three.js object.
+
+- **Literals**: When you pass a direct value like a number, boolean, or a
+  Three.js object.
   - Example: `uniform(1.0)` is inferred as "number".
   - Example: `uniform(new THREE.Vector3(0, 1, 0))` is inferred as "vector3".
-- **Variables with Obvious Types**: When you pass a variable that has a clear type from its declaration.
+- **Variables with Obvious Types**: When you pass a variable that has a clear
+  type from its declaration.
   - Example:
     ```javascript
     const vec = new THREE.Vector3(0, 1, 0);
     const position = uniform(vec); // Inferred as "vector3"
     ```
 
-In these cases, you don't need to pass the type explicitly—the plugin will handle it for you.
+In these cases, you don't need to pass the type explicitly—the plugin will
+handle it for you.
 
 ### When You Must Pass the Type Explicitly
+
 You must provide the type as a second argument in these situations:
-- **Function Calls**: When the value is the result of a function call, as the plugin cannot inspect the return value at compile time.
+
+- **Function Calls**: When the value is the result of a function call, as the
+  plugin cannot inspect the return value at compile time.
   - Example:
     ```javascript
     const position = uniform(randomVector3(), "vec3"); // Type must be specified
     ```
-- **Complex Expressions**: When the value comes from an expression whose type cannot be determined statically.
+- **Complex Expressions**: When the value comes from an expression whose type
+  cannot be determined statically.
   - Example:
     ```javascript
     const value = uniform(Math.random() > 0.5 ? 1 : 0, "float"); // Type should be specified
     ```
 
-If you don't pass the type in these cases, the plugin won't be able to determine the type and will not generate any GUI controls for that uniform.
+If you don't pass the type in these cases, the plugin won't be able to determine
+the type and will not generate any GUI controls for that uniform.
 
 ## License
+
 MIT
 
 ## Contributing
+
 Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
support @range/@uniform-range comments to configure Tweakpane controls

- Parse preceding comments for number/vector uniforms and apply { min, max, step }
- Inject parsed range options into generated bindings
- Update example to annotate uniforms
- Docs: add Range Configuration section and clarify type inference guidance